### PR TITLE
Django admin UI fix

### DIFF
--- a/django_quill/templates/django_quill/widget.html
+++ b/django_quill/templates/django_quill/widget.html
@@ -1,5 +1,5 @@
 {% load static %}
-<div class="vLargeTextField django-quill-widget-container">
+<div class="vLargeTextField django-quill-widget-container form-row">
     <div id="quill-{{ id }}" class="django-quill-widget" data-config="{{ config }}" data-type="django-quill"></div>
     <input id="quill-input-{{ id }}" name="{{ name }}" type="hidden">
     <script>


### PR DESCRIPTION
To bring the quill widget in line with form labels on Django admin edit form. Issue with v3.2.8+.